### PR TITLE
:bug: Fix initialization method not finding a Spotilocal port

### DIFF
--- a/dist/src/index.d.ts
+++ b/dist/src/index.d.ts
@@ -1,6 +1,6 @@
 import * as request from 'superagent';
 import { Status } from './status';
-export declare const SPOTILOCAL_IS_NOT_INITIALIZED: string;
+export declare const SPOTILOCAL_IS_NOT_INITIALIZED = "Spotilocal is not initialized";
 export declare class Spotilocal {
     private spotilocalUrl;
     private oauth;
@@ -30,7 +30,7 @@ export declare class Spotilocal {
      */
     static getCsrfToken(spotilocalUrl: string): Promise<string>;
     /**
-     * Gets spotilocal appi url with port in range 4370-4380.
+     * Gets spotilocal api url with port in range 4370-4380.
      */
     static getSpotilocalUrl(): Promise<string>;
     /**

--- a/dist/src/index.js
+++ b/dist/src/index.js
@@ -5,8 +5,8 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-var request = require('superagent');
-var https = require('https');
+Object.defineProperty(exports, "__esModule", { value: true });
+var request = require("superagent");
 function failIfNotInitialized(target, propertyKey, descriptor) {
     var fn = descriptor.value;
     if (typeof fn !== 'function') {
@@ -110,18 +110,17 @@ var Spotilocal = (function () {
         });
     };
     /**
-     * Gets spotilocal appi url with port in range 4370-4380.
+     * Gets spotilocal api url with port in range 4370-4380.
      */
     Spotilocal.getSpotilocalUrl = function () {
-        var subdomain = 'tommarvoloriddle'.split('').map(function (v, i, arr) {
-            return arr[Math.floor(Math.random() * arr.length)];
-        }).join('');
         return new Promise(function (resolve, reject) {
             var tryGetSpotilocalVersion = function (port) {
                 if (port > 4380) {
-                    reject('It looks like spotify isn\'t open. We failed to find spotiflocal url with ports in range 4370-4380.');
+                    reject('It looks like Spotify isn\'t open. We failed to find spotilocal url with ports in range 4370-4380.');
+                    return;
                 }
-                var possibleUrl = "https://" + subdomain + ".spotilocal.com:" + port + "/";
+                var possibleUrl = "http://127.0.0.1:" + port + "/";
+                console.log(possibleUrl);
                 Spotilocal.getSpotilocalVersion(possibleUrl).then(function () { resolve(possibleUrl); }).catch(function () {
                     tryGetSpotilocalVersion(port + 1);
                 });
@@ -149,19 +148,19 @@ var Spotilocal = (function () {
      * Sets rejectUnauthorized to false, Origin to https://open.spotify.com and timeout to 1000
      */
     Spotilocal.requestToAbsolutelyUglyNotSecuredRequest = function (request) {
-        return request.agent(new https.Agent({ rejectUnauthorized: false }))
+        return request
             .set('Origin', 'https://open.spotify.com')
             .timeout(1000);
     };
-    __decorate([
-        failIfNotInitialized
-    ], Spotilocal.prototype, "getStatus", null);
-    __decorate([
-        failIfNotInitialized
-    ], Spotilocal.prototype, "pause", null);
-    __decorate([
-        failIfNotInitialized
-    ], Spotilocal.prototype, "play", null);
     return Spotilocal;
 }());
+__decorate([
+    failIfNotInitialized
+], Spotilocal.prototype, "getStatus", null);
+__decorate([
+    failIfNotInitialized
+], Spotilocal.prototype, "pause", null);
+__decorate([
+    failIfNotInitialized
+], Spotilocal.prototype, "play", null);
 exports.Spotilocal = Spotilocal;

--- a/dist/src/status.js
+++ b/dist/src/status.js
@@ -1,1 +1,2 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/dist/test/test.js
+++ b/dist/test/test.js
@@ -1,6 +1,7 @@
 "use strict";
-var index_1 = require('../src/index');
-var chai_1 = require('chai');
+Object.defineProperty(exports, "__esModule", { value: true });
+var index_1 = require("../src/index");
+var chai_1 = require("chai");
 describe('#init()', function () {
     this.timeout(10000);
     it('should init spotilocal', function (done) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import * as request from 'superagent';
-import * as https from 'https';
 import {Status} from './status';
 
 function failIfNotInitialized(target: any, propertyKey: string, descriptor: PropertyDescriptor):PropertyDescriptor{
@@ -120,19 +119,17 @@ export class Spotilocal {
     }
 
     /**
-     * Gets spotilocal appi url with port in range 4370-4380.
+     * Gets spotilocal api url with port in range 4370-4380.
      */
     public static getSpotilocalUrl(): Promise<string> {
-        const subdomain = 'tommarvoloriddle'.split('').map((v, i, arr) => {
-            return arr[Math.floor(Math.random() * arr.length)];
-        }).join('');
-
         return new Promise((resolve, reject) => {
             const tryGetSpotilocalVersion = (port: number) => {
                 if (port > 4380) {
-                    reject('It looks like spotify isn\'t open. We failed to find spotiflocal url with ports in range 4370-4380.');
+                    reject('It looks like Spotify isn\'t open. We failed to find spotilocal url with ports in range 4370-4380.');
+                    return;
                 }
-                const possibleUrl = `https://${subdomain}.spotilocal.com:${port}/`;
+                const possibleUrl = `http://127.0.0.1:${port}/`;
+                console.log(possibleUrl);
                 Spotilocal.getSpotilocalVersion(possibleUrl).then(() => { resolve(possibleUrl) }).catch(() => {
                     tryGetSpotilocalVersion(port + 1);
                 });
@@ -161,7 +158,7 @@ export class Spotilocal {
      * Sets rejectUnauthorized to false, Origin to https://open.spotify.com and timeout to 1000
      */
     public static requestToAbsolutelyUglyNotSecuredRequest(request: request.SuperAgentRequest): request.SuperAgentRequest {
-        return request.agent(new https.Agent({ rejectUnauthorized: false }))
+        return request
             .set('Origin', 'https://open.spotify.com')
             .timeout(1000);
     }


### PR DESCRIPTION
Spotify changed their Spotilocal API. They're not listening to a *.spotilocal.com domain on HTTPS anymore, but instead they listen on 127.0.0.1 via HTTP. This PR fixes problems that occured due to this change.